### PR TITLE
Prepare static build for Vercel

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 build
-dist / media
+dist
+/media
 node_modules
 .DS_Store
 .env

--- a/README.md
+++ b/README.md
@@ -307,6 +307,13 @@ export default buildConfig({
 
 There is also a simplified [one click deploy](https://github.com/payloadcms/payload/tree/templates/with-vercel-postgres) to Vercel should you need it.
 
+#### Static deployments
+
+If you only need a static front-end, add `output: 'export'` to your
+`next.config.js` and create a minimal `vercel.json` pointing Vercel at the
+`dist` directory. Running `npm run build` will then generate the fully static
+site that can be deployed without any server functions.
+
 ### Self-hosting
 
 Before deploying your app, you need to:

--- a/next.config.js
+++ b/next.config.js
@@ -21,6 +21,7 @@ const nextConfig = {
     ],
   },
   reactStrictMode: true,
+  output: 'export',
   redirects,
 }
 

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "buildCommand": "npm run build",
+  "outputDirectory": "dist",
+  "framework": "nextjs"
+}


### PR DESCRIPTION
## Summary
- fix `.gitignore`
- add `output: 'export'` to Next.js config
- add example of static deployment to Vercel in README
- add `vercel.json` with static output directory

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686272990898832caa2e9973b114c979