### PR TITLE
Use admin-configured heroes on static pages

### DIFF
--- a/src/app/(frontend)/about-us/page.tsx
+++ b/src/app/(frontend)/about-us/page.tsx
@@ -4,19 +4,20 @@ import React from 'react'
 import Image from 'next/image'
 import Link from 'next/link'
 
+import type { Page as PageType } from '@/payload-types'
+import { RenderHero } from '@/heros/RenderHero'
+import { getCachedDocument } from '@/utilities/getDocument'
+
 export const metadata: Metadata = {
   title: 'About Us | Primedent',
 }
 
-export default function AboutUsPage () {
+export default async function AboutUsPage() {
+  const page = (await getCachedDocument('pages', 'about-us')()) as PageType | null
 
   return (
     <div className="relative text-brand-white overflow-hidden">
-      {/* Hero Section */}
-      <div className="text-center pt-20 pb-10">
-        <h1 className="text-5xl font-bold">About Us</h1>
-        <p className="text-brand-light">Home - About Us</p>
-      </div>
+      <RenderHero {...page?.hero} />
 
       {/* Who We Are Section */}
       <div className="max-w-screen-xl mx-auto px-6 md:flex md:items-center md:gap-10 mb-24">

--- a/src/app/(frontend)/contact-us/page.tsx
+++ b/src/app/(frontend)/contact-us/page.tsx
@@ -1,18 +1,19 @@
 import type { Metadata } from 'next'
 import React from 'react'
 
+import type { Page as PageType } from '@/payload-types'
+import { RenderHero } from '@/heros/RenderHero'
+import { getCachedDocument } from '@/utilities/getDocument'
+
 export const metadata: Metadata = {
   title: 'Contact Us | Primedent',
 }
 
-export default function ContactUsPage() {
+export default async function ContactUsPage() {
+  const page = (await getCachedDocument('pages', 'contact-us')()) as PageType | null
   return (
      <div className="relative text-brand-white overflow-hidden min-h-screen">
-      {/* Top Title Section */}
-      <div className="text-center pt-20 pb-10">
-        <h1 className="text-4xl md:text-6xl font-heading">Contact Us</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Home - Contact Us</p>
-      </div>
+      <RenderHero {...page?.hero} />
 
       {/* Contact Form + Info */}
       <div className="max-w-screen-xl mx-auto mt-20 px-6 md:flex md:gap-20 md:items-start mb-10">

--- a/src/app/(frontend)/dr-serhat/page.tsx
+++ b/src/app/(frontend)/dr-serhat/page.tsx
@@ -2,18 +2,19 @@ import type { Metadata } from 'next'
 import React from 'react'
 import Image from 'next/image'
 
+import type { Page as PageType } from '@/payload-types'
+import { RenderHero } from '@/heros/RenderHero'
+import { getCachedDocument } from '@/utilities/getDocument'
+
 export const metadata: Metadata = {
   title: 'Dr. Serhat | Primedent',
 }
 
-export default function DrSerhatPage() {
+export default async function DrSerhatPage() {
+  const page = (await getCachedDocument('pages', 'dr-serhat')()) as PageType | null
   return (
     <div className="relative text-brand-white overflow-hidden min-h-screen">
-      {/* Top Title Section */}
-      <div className="text-center pt-20 pb-10">
-        <h1 className="text-4xl md:text-6xl font-heading">Dr. Serhat</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Home - Dr. Serhat</p>
-      </div>
+      <RenderHero {...page?.hero} />
 
       {/* Doctor Profile */}
       <div className="max-w-screen-xl mx-auto px-6 md:flex md:gap-10 md:items-start mb-16 mt-20">

--- a/src/app/(frontend)/page.tsx
+++ b/src/app/(frontend)/page.tsx
@@ -1,15 +1,24 @@
 import type { Metadata } from 'next'
 import React from 'react'
 
+import type { Page as PageType } from '@/payload-types'
+import { RenderHero } from '@/heros/RenderHero'
+import { getCachedDocument } from '@/utilities/getDocument'
+
 export const metadata: Metadata = {
   title: 'Home | Primedent',
 }
 
-export default function Page() {
+export default async function Page() {
+  const page = (await getCachedDocument('pages', 'home')()) as PageType | null
+
   return (
-    <main className="container py-24">
-      <h1 className="text-3xl font-bold mb-4">Welcome to Primedent</h1>
-      <p>This is a placeholder homepage. Replace this content with your own.</p>
-    </main>
+    <div className="relative text-brand-white overflow-hidden">
+      <RenderHero {...page?.hero} />
+      <main className="container py-24">
+        <h1 className="text-3xl font-bold mb-4">Welcome to Primedent</h1>
+        <p>This is a placeholder homepage. Replace this content with your own.</p>
+      </main>
+    </div>
   )
 }

--- a/src/app/(frontend)/services/page.tsx
+++ b/src/app/(frontend)/services/page.tsx
@@ -3,11 +3,16 @@ import React from 'react'
 
 import Image from 'next/image'
 
+import type { Page as PageType } from '@/payload-types'
+import { RenderHero } from '@/heros/RenderHero'
+import { getCachedDocument } from '@/utilities/getDocument'
+
 export const metadata: Metadata = {
   title: 'Services | Primedent',
 }
 
-export default function ServicesPage() {
+export default async function ServicesPage() {
+  const page = (await getCachedDocument('pages', 'services')()) as PageType | null
   const services = [
     {
       title: 'Dental Implants',
@@ -43,11 +48,7 @@ export default function ServicesPage() {
 
   return (
     <div className="bg-background text-foreground">
-      {/* Hero Section */}
-      <section className="py-20 text-center">
-        <h1 className="text-4xl md:text-6xl font-heading">Services</h1>
-        <p className="mt-2 text-sm text-muted-foreground">Home - Services</p>
-      </section>
+      <RenderHero {...page?.hero} />
 
       {/* Services Grid */}
       <section className=" max-w-screen-xl m-auto grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-12 pb-24">


### PR DESCRIPTION
## Summary
- fetch hero data from Payload for home and static pages
- show hero using existing `<RenderHero>` component

## Testing
- `npm run lint` *(fails: cross-env not found)*
- `npm run build` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_68639a1b47e4832ca971b2602474ffac