### PR TITLE
Configure static export for Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -23,6 +23,8 @@ const nextConfig = {
   },
   reactStrictMode: true,
   redirects,
+  // Enable static export to generate a fully static site
+  output: 'export',
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- enable Next.js static export via `output: 'export'`
- add `vercel.json` so Vercel serves the `dist` directory

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686ba14a52b4832c9de41151dd508b9d