### PR TITLE
Enable static export for Vercel

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -24,7 +24,7 @@ const nextConfig = {
   reactStrictMode: true,
   redirects,
   // Enable static export to generate a fully static site
-  // output: 'export',
+  output: 'export',
 }
 
 export default withPayload(nextConfig, { devBundleServerPackages: false })

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,3 @@
+{
+  "outputDirectory": "dist"
+}


### PR DESCRIPTION
## Summary
- activate `output: 'export'` to let Next.js generate a static site
- add `vercel.json` so Vercel serves the generated `dist` directory

## Testing
- `npm run lint` *(fails: cross-env not found)*
- `npm run build` *(fails: cross-env not found)*

------
https://chatgpt.com/codex/tasks/task_e_686d7bcd3e48832c87cd8eefc7a87b4d